### PR TITLE
Pipe stderr to stdout 

### DIFF
--- a/templates/memcached-RedHat.conf.j2
+++ b/templates/memcached-RedHat.conf.j2
@@ -16,4 +16,4 @@ CACHESIZE="{{ memcached_memory_limit }}"
 # -l Specify which IP address to listen on. The default is to listen on all IP addresses
 #    This parameter is one of the only security measures that memcached has, so make sure
 #    it's listening on a firewalled interface.
-OPTIONS="-l {{ memcached_listen_ip }} {{ memcached_log_verbosity }} >> {{ memcached_log_file }}"
+OPTIONS="-l {{ memcached_listen_ip }} {{ memcached_log_verbosity }} >> {{ memcached_log_file }} 2>&1"


### PR DESCRIPTION
RHEL's init scripts don't seem to handle the logfile param like debian based systems do. 
