### PR TITLE
Allow non-standard tcp/udp ports using SELinux

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,3 +1,12 @@
 ---
 - name: Install Memcached.
   yum: name=memcached state=installed
+
+- name: Allow non-standard memcached ports with SELinux (tcp).
+  seport: ports="{{memcached_port}}" proto=tcp setype=memcache_port_t state=present
+  when: memcached_port != 11211 and ansible_version.string|version_compare('2.0', '>=')
+
+- name: Allow non-standard memcached ports with SELinux (udp).
+  seport: ports="{{memcached_port}}" proto=udp setype=memcache_port_t state=present
+  when: memcached_port != 11211 and ansible_version.string|version_compare('2.0', '>=')
+


### PR DESCRIPTION
This pull request adds seport: calls to allow memcached to use non-standard ports on RH/CentOS (where SELinux is enabled by default).

It'll work only on recent ansible version (because seport module is available only since 2.0). On older versions seport: calls will be skipped with a version check.
