### PR TITLE
Updates to galaxy meta info.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,6 +16,7 @@ galaxy_info:
       versions:
       - precise
       - trusty
+      - xenial
     - name: Debian
       versions:
       - all


### PR DESCRIPTION
Add Xenial Xerus to list of supported Ubuntu versions,
after properly testing that it works just fine.
