### PR TITLE
Ensure the service runs with the right config right after installation

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,3 @@
 ---
 - name: restart memcached
   service: name=memcached state=restarted
-  when: not memcached_install.changed


### PR DESCRIPTION
When running the role for the first time `memcached` is started right after installation before the settings file is even copied, so the service is running with default config.

I removed the condition in the `restart memcached` handler to ensure the service uses the right config.

This should fix #11.