### PR TITLE
Create an empty memcached.log file with the appropriate permissions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,13 @@
   package: name=memcached state=installed
   register: memcached_install
 
+- name: Create Memcached log file.
+  file:
+    path: "{{memcached_log_file}}"
+    mode: 0600
+    owner: "{{memcached_user}}"
+    state: touch
+
 # Configure Memcached.
 - name: Copy Memcached configuration.
   template:


### PR DESCRIPTION
At least on Fedora, there isn't a placeholder memcached log file, so any output memcached does provide (e.g. if it's configured with -v) will never be written.