### PR TITLE
Support slab size configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,5 @@ memcached_connections: 1024
 
 memcached_log_file: /var/log/memcached.log
 memcached_log_verbosity: ""
+
+memcached_slab_size: "1m"

--- a/templates/memcached-Debian.conf.j2
+++ b/templates/memcached-Debian.conf.j2
@@ -41,3 +41,6 @@ logfile {{ memcached_log_file }}
 
 # Maximize core file limit
 # -r
+
+# Override the default size of each slab page. The default size is 1mb.
+-I {{ memcached_slab_size }}

--- a/templates/memcached-RedHat.conf.j2
+++ b/templates/memcached-RedHat.conf.j2
@@ -17,4 +17,4 @@ CACHESIZE="{{ memcached_memory_limit }}"
 # -l Specify which IP address to listen on. The default is to listen on all IP addresses
 #    This parameter is one of the only security measures that memcached has, so make sure
 #    it's listening on a firewalled interface.
-OPTIONS="-l {{ memcached_listen_ip }} {{ memcached_log_verbosity }} >> {{ memcached_log_file }} 2>&1"
+OPTIONS="-l {{ memcached_listen_ip }} -I {{ memcached_slab_size }} {{ memcached_log_verbosity }} >> {{ memcached_log_file }} 2>&1"


### PR DESCRIPTION
Adding support for slab size configuration option. Added a new default value of 1m for memcached_slab_size. Uses memcached_slab_size in Debian and RedHat templates. Tested.

From memcached readme:
Override the default size of each slab page. The default size is 1mb. Default
value for this parameter is 1m, minimum is 1k, max is 128m.
Adjusting this value changes the item size limit.