### PR TITLE
Allow to use external repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ None.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
+    memcached_enablerepo: ""
+
+(RedHat/CentOS only) If you have enabled any additional repositories (might I suggest geerlingguy.repo-remi), those repositories can be listed under this variable (e.g. `remi`). This can be handy, as an example, if you want to install the latest version of Memcached from Remi's repository.
+
     memcached_user: memcache
 
 The user under which the Memcached daemon will run.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+# Used for RHEL/CentOS/Fedora only. Allows the use of different repos.
+memcached_enablerepo: ""
+
 memcached_port: 11211
 memcached_listen_ip: 127.0.0.1
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,13 +9,11 @@
   when: memcached_user is not defined
 
 # Setup/install tasks.
-- name: Update apt cache.
-  apt: update_cache=yes cache_valid_time=86400
-  when: ansible_os_family == 'Debian'
+- include_tasks: setup-RedHat.yml
+  when: ansible_os_family == 'RedHat'
 
-- name: Install Memcached.
-  package: name=memcached state=present
-  register: memcached_install
+- include_tasks: setup-Debian.yml
+  when: ansible_os_family == 'Debian'
 
 # Configure Memcached.
 - name: Copy Memcached configuration.

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,0 +1,9 @@
+---
+- name: Update apt cache.
+  apt: update_cache=yes cache_valid_time=86400
+
+- name: Ensure Memcached is installed.
+  apt:
+    name: memcached
+    state: present
+  register: memcached_install

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,0 +1,7 @@
+---
+- name: Ensure Memcached is installed.
+  package:
+    name: memcached
+    state: present
+    enablerepo: "{{ memcached_enablerepo | default(omit, true) }}"
+  register: memcached_install


### PR DESCRIPTION
This is needed to install the latest `memcached` from [Remi's RPM repository](https://rpms.remirepo.net/enterprise/7/remi/x86_64/repoview/memcached.html).