### PR TITLE
Remove the when condition from the restart handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,3 @@
 ---
 - name: restart memcached
   service: name=memcached state=restarted
-  when: not memcached_install.changed


### PR DESCRIPTION
I don't see the point of this condition. When I roll out a new memcached and set the memcached_memory_limit or the memcached_listen_ip, this will not become active because this role will not restart memcached if it has just been installed. Currently I have to do this manually.

Is there any usecase for this condition?